### PR TITLE
Fixed build issues relating to issue #5

### DIFF
--- a/swarm_robot_description/package.xml
+++ b/swarm_robot_description/package.xml
@@ -42,6 +42,9 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
   
   <build_depend>roscpp</build_depend>
+  <build_depend>swarm_robot_msg</build_depend>
+  <build_depend>swarm_robot_srv</build_depend>
+  <build_depend>swarm_robot_action</build_depend>
   <run_depend>roscpp</run_depend>
 
   <!-- Eigen requires cmake_modules -->

--- a/swarm_robot_simulation/package.xml
+++ b/swarm_robot_simulation/package.xml
@@ -42,12 +42,14 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
   <build_depend>roscpp</build_depend>
 <build_depend>std_msgs</build_depend>
-<build_depend>swarm_robot_msgs</build_depend>
-<build_depend>swarm_robot_action</build_depend>
+  <build_depend>swarm_robot_msg</build_depend>
+  <build_depend>swarm_robot_srv</build_depend>
+  <build_depend>swarm_robot_action</build_depend>
   <run_depend>roscpp</run_depend>
 <run_depend>std_msgs</run_depend>
 <run_depend>swarm_robot_msgs</run_depend>
 <run_depend>swarm_robot_action</run_depend>
+<run_depend>swarm_robot_srv</run_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- You can specify that this package is a metapackage here: -->


### PR DESCRIPTION
Added <build_depend> tags to packages `swarm_robot_description` and `swarm_robot_simulation` which corrected the build issues for me on ROS Kinetic Kame, Ubuntu 16.04.